### PR TITLE
Discontiunation and native namespace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 Python Docker application
 -----------------
 
+## NOTICE
+
+**This project is no longer maintained. The new version of the library is available at:** 
+**[keboola.component PYPI project](https://pypi.org/project/keboola.component)**
+
 [![Build Status](https://travis-ci.org/keboola/python-docker-application.svg?branch=master)](https://travis-ci.org/keboola/python-docker-application)
 [![Code Climate](https://codeclimate.com/github/keboola/python-docker-application/badges/gpa.svg)](https://codeclimate.com/github/keboola/python-docker-application)
 

--- a/keboola/__init__.py
+++ b/keboola/__init__.py
@@ -1,5 +1,0 @@
-"""
-Module representing common interface to KBC docker applications
-See docs: https://developers.keboola.com/extend/common-interface/
-"""
-__all__ = ['docker']

--- a/keboola/docker/__init__.py
+++ b/keboola/docker/__init__.py
@@ -1,0 +1,10 @@
+"""
+
+**NOTE:** This module is no longer maintained. A new official version is present at the PYPI
+https://pypi.org/project/keboola.component
+
+Module representing common interface to KBC docker applications
+See docs: https://developers.keboola.com/extend/common-interface/
+"""
+
+from .docker import Config

--- a/keboola/docker/docker.py
+++ b/keboola/docker/docker.py
@@ -1,4 +1,7 @@
 """
+
+**NOTE:** This module is no longer maintained. A new official version is present at the PYPI https://pypi.org/project/keboola.component
+
 Module representing common interface to KBC docker applications
 See docs: https://developers.keboola.com/extend/common-interface/
 """

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='Keboola',
-    version='2.1.0',
+    version='2.2.0',
     url='https://github.com/keboola/python-docker-application',
-    packages=['keboola'],
+    packages=['keboola.docker']
 )


### PR DESCRIPTION
Hi we've released the https://github.com/keboola/python-component library that replaces this one (covers all its functionality). 

The new packages are under the `keboola` namespace on PYPI and are using [native namespaces](https://packaging.python.org/guides/packaging-namespace-packages/#native-namespace-packages). So I've changed the package structure to support it and avoid any clashes if they were to coexist together (Python transformations perhaps) to prevent any failures of existing code.

I've also added a note with link to the new repository.

This is to be followed by an update to the developer-docs, etc.